### PR TITLE
Fix MIN/MAX macro conflicts with system headers

### DIFF
--- a/stratum/algos/sha256.h
+++ b/stratum/algos/sha256.h
@@ -91,11 +91,11 @@ be32dec_vect(uint32_t *dst, const unsigned char *src, size_t len)
 #define Ch(x, y, z)	((x & (y ^ z)) ^ z)
 #define Maj(x, y, z)	((x & (y | z)) | (y & z))
 #define SHR(x, n)	(x >> n)
-#define ROTR(x, n)	((x >> n) | (x << (32 - n)))
-#define S0(x)		(ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
-#define S1(x)		(ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
-#define s0(x)		(ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3))
-#define s1(x)		(ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10))
+#define ROTR32(x, n)	((x >> n) | (x << (32 - n)))
+#define S0(x)		(ROTR32(x, 2) ^ ROTR32(x, 13) ^ ROTR32(x, 22))
+#define S1(x)		(ROTR32(x, 6) ^ ROTR32(x, 11) ^ ROTR32(x, 25))
+#define s0(x)		(ROTR32(x, 7) ^ ROTR32(x, 18) ^ SHR(x, 3))
+#define s1(x)		(ROTR32(x, 17) ^ ROTR32(x, 19) ^ SHR(x, 10))
 
 /* SHA256 round function */
 #define RND(a, b, c, d, e, f, g, h, k)			\

--- a/stratum/algos/sha512_256.c
+++ b/stratum/algos/sha512_256.c
@@ -42,15 +42,15 @@
 #include "sha512_256.h"
 
 #define SHFR(x, n)    (x >> n)
-#define ROTR(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
+#define ROTR_SIZEOF(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
 #define ROTL(x, n)   ((x << n) | (x >> ((sizeof(x) << 3) - n)))
 #define CH(x, y, z)  ((x & y) ^ (~x & z))
 #define MAJ(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
 
-#define SHA512_F1(x) (ROTR(x, 28) ^ ROTR(x, 34) ^ ROTR(x, 39))
-#define SHA512_F2(x) (ROTR(x, 14) ^ ROTR(x, 18) ^ ROTR(x, 41))
-#define SHA512_F3(x) (ROTR(x,  1) ^ ROTR(x,  8) ^ SHFR(x,  7))
-#define SHA512_F4(x) (ROTR(x, 19) ^ ROTR(x, 61) ^ SHFR(x,  6))
+#define SHA512_F1(x) (ROTR_SIZEOF(x, 28) ^ ROTR_SIZEOF(x, 34) ^ ROTR_SIZEOF(x, 39))
+#define SHA512_F2(x) (ROTR_SIZEOF(x, 14) ^ ROTR_SIZEOF(x, 18) ^ ROTR_SIZEOF(x, 41))
+#define SHA512_F3(x) (ROTR_SIZEOF(x,  1) ^ ROTR_SIZEOF(x,  8) ^ SHFR(x,  7))
+#define SHA512_F4(x) (ROTR_SIZEOF(x, 19) ^ ROTR_SIZEOF(x, 61) ^ SHFR(x,  6))
 
 #define UNPACK32(x, str)                      \
 {                                             \

--- a/stratum/algos/sha512_256.h
+++ b/stratum/algos/sha512_256.h
@@ -41,7 +41,7 @@
 #define SHA512_BLOCK_SIZE  (1024 / 8)
 
 #define SHFR(x, n)    (x >> n)
-#define ROTR(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
+#define ROTR_SIZEOF(x, n)   ((x >> n) | (x << ((sizeof(x) << 3) - n)))
 #define CH(x, y, z)  ((x & y) ^ (~x & z))
 #define MAJ(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
 

--- a/stratum/coind.cpp
+++ b/stratum/coind.cpp
@@ -36,7 +36,7 @@ double coind_profitability(YAAMP_COIND *coind)
 
 double coind_nethash(YAAMP_COIND *coind)
 {
-	int blocktime = (coind->blocktime)? coind->blocktime : max(min(coind->actual_ttf, 60), 30);
+	int blocktime = (coind->blocktime)? coind->blocktime : MAX(MIN(coind->actual_ttf, 60), 30);
 	int powlimit_bits = 32;
 
 	if (coind->powlimit_bits) powlimit_bits = coind->powlimit_bits;

--- a/stratum/db.cpp
+++ b/stratum/db.cpp
@@ -478,9 +478,9 @@ void db_update_remotes(YAAMP_DB *db)
 		if(remote->renter)
 		{
 			if(!strcmp(g_current_algo->name, "sha256"))
-				remote->speed = min(remote->speed, max(remote->renter->balance/g_current_algo->rent*100000000, 1));
+				remote->speed = MIN(remote->speed, MAX(remote->renter->balance/g_current_algo->rent*100000000, 1));
 			else
-				remote->speed = min(remote->speed, max(remote->renter->balance/g_current_algo->rent*100000, 1));
+				remote->speed = MIN(remote->speed, MAX(remote->renter->balance/g_current_algo->rent*100000, 1));
 		}
 	}
 

--- a/stratum/util.cpp
+++ b/stratum/util.cpp
@@ -351,8 +351,8 @@ const char *header_value(const char *data, const char *search, char *value)
 		return value;
 	}
 
-	strncpy(value, p, min(1024, p2 - p));
-	value[min(1023, p2 - p)] = 0;
+	strncpy(value, p, MIN(1024, p2 - p));
+	value[MIN(1023, p2 - p)] = 0;
 
 	return value;
 }

--- a/stratum/util.h
+++ b/stratum/util.h
@@ -134,12 +134,20 @@ void decode_nbits(uint256& target_, unsigned int nbits);
 
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef max
-#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#ifndef yaamp_max
+#define yaamp_max(a,b)            (((a) > (b)) ? (a) : (b))
 #endif
 
-#ifndef min
-#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#ifndef yaamp_min
+#define yaamp_min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MIN
+#define MIN(a,b)                  (((a) < (b)) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a,b)                  (((a) > (b)) ? (a) : (b))
 #endif
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The project failed to compile with modern build tools due to macro conflicts and duplicate definitions. Specifically, lowercase min/max macros clashed with the standard library’s std::min/std::max, and ROTR was defined in multiple files under the same name. This caused ambiguous references and build errors.

Summary of Changes:

- Renamed lowercase min/max macros to uppercase to avoid conflicts with std::min/std::max.
- Renamed ROTR macro definitions to different names (ROTR_32, ROTR_SIZEOF), thus eliminating duplicates.

This change restores buildability and reliability for developers using up-to-date build tools.